### PR TITLE
Fix UnboundLocalError in get_network_info on request failure

### DIFF
--- a/audioflow2mqtt.py
+++ b/audioflow2mqtt.py
@@ -163,6 +163,7 @@ class AudioflowDevice:
                 device_info = await httpx_async.get(url=device_url + 'switch', timeout=self.timeout)    
             except Exception as e:
                 logging.error(f'Unable to get network info: {e}')
+                return  # skip this cycle; the next poll will retry
             device_info = json.loads(device_info.text)
             wifi = device_info['wifi']
             ssid = wifi[:wifi.find('[')].strip()


### PR DESCRIPTION
The httpx GET was wrapped in a try/except that only logged on failure, then unconditionally read device_info.text on the next line. When the request raised, device_info was never assigned, so the poll loop crashed with UnboundLocalError. Return early on failure so the next poll cycle retries.